### PR TITLE
Demo: local cable updates

### DIFF
--- a/app/controllers/action_cable/commands_controller.rb
+++ b/app/controllers/action_cable/commands_controller.rb
@@ -1,0 +1,114 @@
+module ActionCable
+  # An HTTP version of command executor for Action Cable
+  class CommandsController < ApplicationController
+    skip_before_action :verify_authenticity_token
+
+    using(Module.new do
+      # Add #load method to Subscriptions to create a channel instance.
+      # (Code borrowed from anycable-rails)
+      refine ::ActionCable::Connection::Subscriptions do
+        def load(identifier)
+          return subscriptions[identifier] if subscriptions[identifier]
+
+          subscription = subscription_from_identifier(identifier)
+          raise "Channel not found: #{ActiveSupport::JSON.decode(identifier).fetch("channel")}" unless subscription
+
+          subscriptions[identifier] = subscription
+        end
+      end
+    end)
+
+    def open
+      connection.handle_open
+
+      respond_with_socket_state
+    end
+
+    def message
+      command_params = params
+      if on_wasm?
+        command_params = JSON.parse(request.raw_post).with_indifferent_access
+      end
+
+      command = command_params[:command]
+      identifier = command_params[:identifier]
+      data = command_params[:data]
+
+      # Initialize the channel instance
+      connection.subscriptions.load(identifier) unless command == "subscribe"
+
+      connection.handle_incoming({"command" => command, "identifier" => identifier, "data" => data}.compact)
+
+      respond_with_socket_state(identifier:)
+    end
+
+    def close
+      head :ok
+    end
+
+    private
+
+    def respond_with_socket_state(**other)
+      render json: {transmissions: socket.transmissions, streams: socket.streams, state: {}, stopped_streams: socket.stopped_streams}.merge(other)
+    end
+
+    class ServerInterface < SimpleDelegator
+      attr_accessor :pubsub
+    end
+
+    class Socket
+      #== Action Cable socket interface ==
+      attr_reader :logger, :protocol, :request
+      attr_reader :transmissions, :streams, :stopped_streams, :coder, :server
+
+      delegate :env, to: :request
+      delegate :worker_pool, :logger, :perform_work, to: :server
+
+      def initialize(request, server, coder: ActiveSupport::JSON)
+        @request = request
+        @coder = coder
+        @server = server
+        @transmissions = []
+        @streams = []
+        @stopped_streams = []
+      end
+
+      def transmit(data)
+        transmissions << coder.encode(data)
+      end
+
+      def subscribe(channel, handler, on_success = nil)
+        streams << channel
+        on_success&.call
+      end
+
+      def unsubscribe(channel, handler)
+        stopped_streams << channel
+      end
+
+      def close
+      end
+    end
+
+    def socket
+      @socket ||= begin
+        state = request.headers["HTTP_X_CABLE_STATE"].then do |rawState|
+          next unless rawState
+          JSON.parse(rawState).with_indifferent_access
+        end
+
+        Socket.new(request, server)
+      end
+    end
+
+    def connection
+      @connection ||= begin
+        srv = ServerInterface.new(socket)
+        srv.pubsub = socket
+        server.config.connection_class.call.new(srv, socket)
+      end
+    end
+
+    def server = ActionCable.server
+  end
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,6 +2,7 @@
 import "@hotwired/turbo";
 import { createCable } from "@anycable/web";
 import { start } from "@anycable/turbo-stream";
+import { LocalTransport } from "local_cable";
 
 // Check if actioncable meta tag contains the URL
 const actionCableMeta = document.querySelector('meta[name="action-cable-url"]');
@@ -10,6 +11,12 @@ const actionCableUrl = actionCableMeta ? actionCableMeta.content : null;
 if (actionCableUrl && actionCableUrl.startsWith("null://")) {
   console.log("No Action Cable configured")
 } else {
-  const cable = createCable({ logLevel: "debug" });
+  let opts = { logLevel: "debug" };
+
+  if (actionCableUrl?.startsWith("local://")) {
+    opts.transport = new LocalTransport(actionCableUrl.replace("local://", ""));
+  }
+
+  const cable = createCable(opts);
   start(cable, { delayedUnsubscribe: true });
 }

--- a/app/javascript/local_cable.js
+++ b/app/javascript/local_cable.js
@@ -1,0 +1,176 @@
+import { createNanoEvents } from "nanoevents";
+
+export class LocalTransport {
+  constructor(url, opts = {}) {
+    if (typeof BroadcastChannel === "undefined") {
+      throw new Error("No BroadcastChannel support");
+    }
+
+    this.streamToIdentifier = {};
+
+    this.url = url;
+    this.pingInterval = opts.pingInterval || 3000;
+    this.fetchCredentials = opts.credentials || "same-origin";
+
+    this.connected = false;
+    this.emitter = createNanoEvents();
+    this.emulatePing = this.emulatePing.bind(this);
+
+    let fetchFn = opts.fetchImplementation;
+
+    if (fetchFn) {
+      this.fetch = fetchFn;
+    } else if (typeof fetch !== "undefined") {
+      this.fetch = (...args) => fetch(...args);
+    } else {
+      throw new Error("No fetch support");
+    }
+
+    this.channel = opts.channel || "action_cable";
+    this.bc = new BroadcastChannel(this.channel);
+    this.bc.onmessage = this.processBroadcast.bind(this);
+  }
+
+  displayName() {
+    return "Local(" + this.url + ")";
+  }
+
+  async open() {
+    try {
+      let response = await this.fetch(this.url + "/open", {
+        method: "POST",
+        credentials: this.fetchCredentials,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (response.ok) {
+        this.connected = true;
+        this.emitter.emit("open");
+
+        await this.processResponse(response);
+
+        this._pingTimer = setInterval(this.emulatePing, this.pingInterval);
+      } else {
+        if (response.status === 401) {
+          await this.processResponse(response);
+        }
+
+        throw new Error(`Unexpected status code: ${response.status}`);
+      }
+    } catch (error) {
+      this.emitter.emit("close", error);
+      throw error;
+    }
+  }
+
+  setURL(url) {
+    this.url = url;
+  }
+
+  setParam(key, val) {
+    let url = new URL(this.url);
+    url.searchParams.set(key, val);
+    let newURL = `${url.protocol}//${url.host}${url.pathname}?${url.searchParams}`;
+    this.setURL(newURL);
+  }
+
+  send(data) {
+    if (!this.connected) {
+      throw Error("No connection");
+    } else {
+      this.sendCommand(data);
+    }
+  }
+
+  async sendCommand(data) {
+    const response = await this.fetch(this.url + "/message", {
+      method: "POST",
+      body: data,
+      credentials: this.fetchCredentials,
+      headers: {
+        "Content-Type": "application/json",
+        "X-Cable-State": JSON.stringify(this.connState),
+      },
+    });
+
+    await this.processResponse(response);
+  }
+
+  async close() {
+    if (this.connected) {
+      this.onclose();
+    }
+  }
+
+  on(event, callback) {
+    return this.emitter.on(event, callback);
+  }
+
+  once(event, callback) {
+    let unbind = this.emitter.on(event, (...args) => {
+      unbind();
+      callback(...args);
+    });
+    return unbind;
+  }
+
+  async processResponse(response) {
+    const data = await response.json();
+
+    if (data.state) {
+      this.connState = data.state;
+    }
+
+    if (data.identifier) {
+      const streams = data.streams || [];
+
+      for (const stream of streams) {
+        this.streamToIdentifier[stream] = data.identifier;
+      }
+    }
+
+    const transmissions = data.transmissions || [];
+    for (const msg of transmissions) {
+      this.emitter.emit("data", msg);
+    }
+  }
+
+  processBroadcast(event) {
+    console.log("broadcast event", event);
+    let data = event.data;
+
+    if (data.data) {
+      const identifier = this.streamToIdentifier[data.stream];
+
+      if (identifier) {
+        console.log(`broadcast message for ${identifier}`, data.data);
+
+        this.emitter.emit(
+          "data",
+          JSON.stringify({ identifier, message: JSON.parse(data.data) }),
+        );
+      }
+    }
+  }
+
+  onclose() {
+    if (this._pingTimer) {
+      clearInterval(this._pingTimer);
+      delete this._pingTimer;
+    }
+
+    this.connected = false;
+    this.emitter.emit("close");
+  }
+
+  emulatePing() {
+    // This is a hack to emulater server-to-client pings
+    // and make monitor work correcly with long-polling
+    this.emitter.emit(
+      "data",
+      `{"type":"ping","source":"local transport emulation"}`,
+    );
+  }
+}

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,6 +2,8 @@ require_relative "boot"
 
 require "wasmify/rails/shim"
 
+$LOAD_PATH.unshift File.expand_path("../lib/rails_ext", __dir__)
+
 require "rails/all"
 
 # Require the gems listed in Gemfile, including any gems
@@ -16,7 +18,7 @@ module OfflineTodos
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w[assets tasks])
+    config.autoload_lib(ignore: %w[assets tasks rails_ext])
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -10,4 +10,4 @@ production:
   channel_prefix: offline_todos_production
 
 wasm:
-  adapter: inline
+  adapter: broadcast_channel

--- a/config/environments/wasm.rb
+++ b/config/environments/wasm.rb
@@ -21,7 +21,7 @@ Rails.application.configure do
   config.cache_store = :memory_store
   config.active_job.queue_adapter = :inline
   config.action_mailer.delivery_method = :null
-  config.action_cable.url = "null://"
+  config.action_cable.url = "local:///action_cable"
 
   if config.respond_to?(:active_storage)
     config.active_storage.variant_processor = :null

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,6 +1,7 @@
 # Pin npm packages by running ./bin/importmap
 
 pin "application"
+pin "local_cable"
 pin "@hotwired/turbo", to: "@hotwired--turbo.js" # @8.0.10
 pin "@anycable/web", to: "@anycable--web.js" # @0.9.0
 pin "@anycable/core", to: "@anycable--core.js" # @0.9.1

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,4 +12,10 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root "todos#index"
+
+  namespace :action_cable do
+    post "/open" => "commands#open"
+    post "/message" => "commands#message"
+    post "/close" => "commands#close"
+  end
 end

--- a/lib/rails_ext/action_cable/subscription_adapter/broadcast_channel.rb
+++ b/lib/rails_ext/action_cable/subscription_adapter/broadcast_channel.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module ActionCable
+  module SubscriptionAdapter
+    class BroadcastChannel < Base
+      def broadcast(channel, payload)
+        Rails.logger.debug "Broadcasting to #{channel}"
+
+        begin
+          JS.global[external_interface].broadcast(channel, payload)
+        rescue => e
+          Rails.logger.error "Failed to broadcast to #{channel}: #{e.message}"
+        end
+      end
+
+      private
+
+      def external_interface
+        @external_interface ||= config_options.fetch(:external_interface, "actionCableBroadcaster")
+      end
+
+      def config_options
+        @config_options ||= config.cable.deep_symbolize_keys
+      end
+    end
+  end
+end

--- a/pwa/local_cable.js
+++ b/pwa/local_cable.js
@@ -1,0 +1,10 @@
+export class ActionCableBroadcaster {
+  constructor() {
+    this.bc = new BroadcastChannel("action_cable");
+  }
+
+  broadcast(stream, data) {
+    console.log("[rails-web] Broadcasting to channel:", stream, data);
+    this.bc.postMessage({ stream, data });
+  }
+}

--- a/pwa/rails.sw.js
+++ b/pwa/rails.sw.js
@@ -6,6 +6,7 @@ import {
 } from "wasmify-rails";
 
 import { setupSQLiteDatabase } from "./database.js";
+import { ActionCableBroadcaster  } from "./local_cable.js";
 
 let db = null;
 
@@ -29,6 +30,8 @@ const initVM = async (progress, opts = {}) => {
   }
 
   registerSQLiteWasmInterface(self, db);
+
+  self.actionCableBroadcaster = new ActionCableBroadcaster();
 
   let redirectConsole = true;
 


### PR DESCRIPTION
## Description

This PR demonstrates how to perform live updates across browser tabs using BroadcastChannel as the transport.

Read also [Action Cable on Wasm](https://writebook-on-wasm.fly.dev/5/ruby-on-rails-on-webassembly/64/action-cable-on-wasm).

## Dependencies

This functionality relies on pluggable architecture of [AnyCable JS SDK](https://github.com/anycable/anycable-client) and [Action Cable Next](https://github.com/anycable/actioncable-next).